### PR TITLE
Update links.yml to point to a proper about page

### DIFF
--- a/_data/links.yml
+++ b/_data/links.yml
@@ -1,5 +1,5 @@
 - url: /
   title: Home
 
-- url: /brume/about
+- url: /about
   title: About


### PR DESCRIPTION
The catalog structure is _about/index.md_ so a _/brume/about_ link will not work and redirect to a 404 page.